### PR TITLE
Add rake task for running TweetBot

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -2,7 +2,7 @@ name: Ruby
 
 on:
     pull_request:
-        branches: 
+        branches:
             - master
 
 jobs:
@@ -20,4 +20,4 @@ jobs:
       run: |
         gem install bundler
         bundle install --jobs 4 --retry 3
-        bundle exec rake
+        bundle exec rake test

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-tweet-bot: bundle exec ruby app/main.rb
+tweet-bot: bundle exec rake

--- a/Rakefile
+++ b/Rakefile
@@ -7,4 +7,8 @@ Rake::TestTask.new do |task|
 end
 desc 'Run tests'
 
-task default: "test"
+task :run do
+    ruby 'app/main.rb'
+end
+desc 'Run the tweet-bot'
+task default: "run"


### PR DESCRIPTION
Now, instead of having to write `ruby app/main.rb`, you can just use the default rake task (`rake`) to run the app!