### PR TITLE
Add parser with roll dice command

### DIFF
--- a/app/lib/dice/dice.rb
+++ b/app/lib/dice/dice.rb
@@ -1,0 +1,13 @@
+module Dice
+    def Dice.roll(num)
+        if num <= 0
+            raise ArgumentError.new('Dice number cannot be below 1')
+        end
+
+        if num > 100
+            raise ArgumentError.new('Dice number cannot be above 100')
+        end
+
+        rand(1..num)
+    end
+end

--- a/app/lib/parser/parser.rb
+++ b/app/lib/parser/parser.rb
@@ -1,0 +1,37 @@
+require_relative '../dice/dice'
+
+module Parser
+    def Parser.parse(tweet)
+        words = tweet.downcase.split(' ')
+
+        msg = self.check_for_roll_cmd(words)
+
+        msg || self.default_response
+    end
+
+    def self.default_response
+        "Thanks for mentioning me ♥️🤖"
+    end
+
+    def self.check_for_roll_cmd(words)
+        roll_index = words.find_index('roll')
+        if roll_index
+            after_roll = words.slice(roll_index + 1, words.length)
+            dice = after_roll.select { |w| w.match(/^d\d+$/) }
+
+            if !dice.empty?
+                # Extract number of dice
+                dice = dice.first
+                dice = dice.delete_prefix('d').to_i
+
+                # Call the dice roll method & format tweet
+                begin
+                    result = Dice.roll(dice)
+                    "Your d#{dice} result was #{result}"
+                rescue ArgumentError => e
+                    e.message
+                end
+            end
+        end
+    end
+end

--- a/app/main.rb
+++ b/app/main.rb
@@ -2,6 +2,7 @@ require 'dotenv/load'
 
 require 'logger'
 require 'twitter'
+require_relative 'lib/parser/parser'
 
 # Turn off log buffering (for Heroku)
 $stdout.sync = true
@@ -48,7 +49,12 @@ begin
     stream.filter( track: topics.join(",") ) do |object|
         log.info("#{object.user.screen_name} said: #{object.text}") if object.is_a? Twitter::Tweet
         timeNow = Time.now.strftime("%H:%M:%S")
-        twitter.update("@#{object.user.screen_name} Thanks for mentioning me ♥️🤖 Time: #{timeNow}", in_reply_to_status: object)
+
+        msg = Parser.parse object.text
+        twitter.update("@#{object.user.screen_name} #{msg}", in_reply_to_status: object)
+        log.info("sending reply to #{object.user.screen_name}: #{msg}")
+
+        # twitter.update("@#{object.user.screen_name} Thanks for mentioning me ♥️🤖 Time: #{timeNow}", in_reply_to_status: object)
     end
 rescue JSON::ParserError => e
     if e.message == "767: unexpected token at 'Exceeded connection limit for user'"

--- a/app/test/dice/test_dice.rb
+++ b/app/test/dice/test_dice.rb
@@ -1,0 +1,64 @@
+require "minitest/autorun"
+require "minitest/reporters"
+Minitest::Reporters.use! Minitest::Reporters::ProgressReporter.new
+
+require_relative '../../lib/dice/dice'
+
+class DiceTest < Minitest::Test
+    def test_should_roll_dice
+        result = Dice.roll(4)
+        assert result.between?(1,4)
+
+        result = Dice.roll(6)
+        assert result.between?(1,6)
+
+        result = Dice.roll(8)
+        assert result.between?(1,8)
+
+        result = Dice.roll(10)
+        assert result.between?(1,10)
+
+        result = Dice.roll(12)
+        assert result.between?(1,12)
+
+        result = Dice.roll(20)
+        assert result.between?(1,20)
+
+        result = Dice.roll(100)
+        assert result.between?(1,100)
+    end
+
+    def test_should_not_accept_dice_pass_100
+        e = assert_raises ArgumentError  do
+            Dice.roll(101)
+        end
+        assert_equal 'Dice number cannot be above 100', e.message
+
+        e = assert_raises ArgumentError  do
+            Dice.roll(200)
+        end
+        assert_equal 'Dice number cannot be above 100', e.message
+
+        e = assert_raises ArgumentError  do
+            Dice.roll(999999)
+        end
+        assert_equal 'Dice number cannot be above 100', e.message
+    end
+
+    def test_should_not_accept_dice_below_zero
+        e = assert_raises ArgumentError  do
+            Dice.roll(0)
+        end
+        assert_equal 'Dice number cannot be below 1', e.message
+
+        e = assert_raises ArgumentError  do
+            Dice.roll(-1)
+        end
+        assert_equal 'Dice number cannot be below 1', e.message
+
+        e = assert_raises ArgumentError  do
+            Dice.roll(-9999)
+        end
+        assert_equal 'Dice number cannot be below 1', e.message
+    end
+end

--- a/app/test/parser/test_parser.rb
+++ b/app/test/parser/test_parser.rb
@@ -1,0 +1,48 @@
+require "minitest/autorun"
+require "minitest/reporters"
+Minitest::Reporters.use! Minitest::Reporters::ProgressReporter.new
+
+require_relative '../../lib/parser/parser'
+
+class ParserTest < Minitest::Test
+    def test_should_parse_roll
+        msg = Parser.parse('roll d6')
+        assert msg.match(/^Your d\d+ result was \d+$/)
+
+        msg = Parser.parse('roll d1')
+        assert msg.match(/^Your d\d+ result was \d+$/)
+
+        msg = Parser.parse('roll d100')
+        assert msg.match(/^Your d\d+ result was \d+$/)
+
+        msg = Parser.parse('@TweetGamesBot ROLL me a D20')
+        assert msg.match(/^Your d\d+ result was \d+$/)
+
+        msg = Parser.parse("Let's see if I'm lucky: @TweetGamesBot, roll a d69")
+        assert msg.match(/^Your d\d+ result was \d+$/)
+    end
+
+    def test_should_not_roll_pass_100
+        msg = Parser.parse('roll d101')
+        assert_equal 'Dice number cannot be above 100', msg
+
+        msg = Parser.parse('roll d200')
+        assert_equal 'Dice number cannot be above 100', msg
+
+        msg = Parser.parse('roll d99999')
+        assert_equal 'Dice number cannot be above 100', msg
+    end
+
+    def test_should_not_roll_d0
+        msg = Parser.parse('roll d0')
+        assert_equal 'Dice number cannot be below 1', msg
+    end
+
+    def test_should_not_parse_d_below_zero
+        result = Parser.parse('roll d-1')
+        assert_equal "Thanks for mentioning me ♥️🤖", result
+
+        result = Parser.parse('roll d-9999')
+        assert_equal "Thanks for mentioning me ♥️🤖", result
+    end
+end


### PR DESCRIPTION
- Bot will not respond to "roll" command e.g. `roll a d6, bot!`
- Works with any dice between 1 and 100
